### PR TITLE
WIP Overrides the dd-handler recipe to use custom gem

### DIFF
--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -33,12 +33,13 @@ git '/usr/local/src/chef-handler-datadog' do
   repository 'https://github.com/Shopify/chef-handler-datadog.git'
   revision 'master'
   action :sync
+  notifies :run, "execute[build_chef-handler-datadog_gem]", :immediately
 end
 
 execute 'build_chef-handler-datadog_gem' do
   cwd '/usr/local/src/chef-handler-datadog'
   command 'gem build chef-handler-datadog.gemspec'
-  action :run
+  action :nothing
 end
 
 chef_gem 'chef-handler-datadog' do


### PR DESCRIPTION
As per https://github.com/Shopify/ops/issues/904
Gem updates https://github.com/Shopify/chef-handler-datadog/pull/1

We need additional roles reported from our servers, so we need to customize the chef-handler-datadog gem and install it. This swaps the dd-handler recipe from the datadog cookbook for a slightly modified version of our own that installs our version of the chef-handler-datadog gem

Concerns that I have at this point, 
- I don't think its idempotent, it will probably try to install every time it runs
- version is hardcoded

Please take a look @wisq @coosh @kvs 

FYI, when I created this the Cheffile was configured to use the `additional-plugins` branch. Therefore I forked and created the PR from that branch  (i.e. there are more changes in relation to master than are shown here)
